### PR TITLE
Feature/water

### DIFF
--- a/Scenes/NewScene02.tscn
+++ b/Scenes/NewScene02.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=22 format=3 uid="uid://vxfj52skora1"]
+[gd_scene load_steps=24 format=3 uid="uid://vxfj52skora1"]
 
 [ext_resource type="Shader" uid="uid://cvd0x7lon1ur6" path="res://addons/sky_3d/shaders/SkyMaterial.gdshader" id="1_yrbqa"]
 [ext_resource type="Texture2D" uid="uid://c1vwcdcdvb74a" path="res://addons/sky_3d/assets/thirdparty/textures/milkyway/Milkyway.jpg" id="2_kro42"]
@@ -8,11 +8,13 @@
 [ext_resource type="Texture2D" uid="uid://djpfuyxkryegn" path="res://addons/sky_3d/assets/textures/noise.jpg" id="6_4p5lh"]
 [ext_resource type="Texture2D" uid="uid://bm7dot7t7u1q4" path="res://addons/sky_3d/assets/thirdparty/textures/milkyway/StarField.jpg" id="7_lvxco"]
 [ext_resource type="Script" uid="uid://7n58awc2ols0" path="res://Scripts/draw_terrain.gd" id="8_5hbym"]
+[ext_resource type="Texture2D" uid="uid://bners57crc7p4" path="res://textures/10768.jpg" id="8_o4ep3"]
 [ext_resource type="Script" uid="uid://deo0gxkmk2ahd" path="res://addons/sky_3d/src/Sky3D.gd" id="9_sk61g"]
 [ext_resource type="Script" uid="uid://b4tkplvh7fq40" path="res://addons/sky_3d/src/Skydome.gd" id="10_p8bqm"]
 [ext_resource type="Script" uid="uid://cjmkcj8hwm7ts" path="res://addons/sky_3d/src/TimeOfDay.gd" id="11_yuxwe"]
 [ext_resource type="Material" uid="uid://bb6i0fqo0hjiv" path="res://materials/water_material.tres" id="12_kro42"]
 [ext_resource type="Script" uid="uid://c4mvk5x5up2dp" path="res://Scripts/mesh_connector.gd" id="13_1ty8j"]
+[ext_resource type="Script" uid="uid://btn8i0m76hx2y" path="res://Scripts/Camera/debug_camera_controller.gd" id="14_mu6w4"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_bi7xu"]
 shader = ExtResource("1_yrbqa")
@@ -53,7 +55,7 @@ shader_parameter/background_color = Color(0.709804, 0.709804, 0.709804, 0.854902
 shader_parameter/stars_field_color = Color(1, 1, 1, 1)
 shader_parameter/stars_field_texture = ExtResource("7_lvxco")
 shader_parameter/sky_alignment = Vector3(2.6555, -0.23935, 0.4505)
-shader_parameter/sky_rotation = -12.9129
+shader_parameter/sky_rotation = -11.8104
 shader_parameter/sky_tilt = -1.29154
 shader_parameter/stars_scintillation = 0.75
 shader_parameter/stars_scintillation_speed = 0.01
@@ -88,8 +90,8 @@ shader_parameter/cumulus_clouds_horizon_light_color = Color(0.98, 0.43, 0.15, 1)
 shader_parameter/cumulus_clouds_night_color = Color(0.090196, 0.094118, 0.129412, 1)
 shader_parameter/cumulus_clouds_partial_mie_phase = Vector3(0.957564, 1.04244, 0.412)
 shader_parameter/cumulus_clouds_mie_intensity = 1.0
-shader_parameter/moon_matrix = Basis(0, 0.562871, -0.826544, -0.723038, -0.570983, -0.388836, -0.690808, 0.597623, 0.406978)
-shader_parameter/deep_space_matrix = Basis(-0.940541, -0.339679, 1.49012e-08, -0.0936285, 0.259249, -0.961261, 0.326521, -0.904106, -0.275638)
+shader_parameter/moon_matrix = Basis(-7.45058e-09, 0.502016, -0.864858, -0.95855, 0.24642, 0.143037, 0.284925, 0.82901, 0.481208)
+shader_parameter/deep_space_matrix = Basis(-0.727591, 0.686011, 0, 0.189091, 0.200552, -0.961261, -0.659436, -0.699405, -0.275638)
 
 [sub_resource type="Sky" id="Sky_ew16t"]
 sky_material = SubResource("ShaderMaterial_bi7xu")
@@ -98,7 +100,7 @@ sky_material = SubResource("ShaderMaterial_bi7xu")
 background_mode = 2
 sky = SubResource("Sky_ew16t")
 ambient_light_source = 3
-ambient_light_color = Color(0.742874, 0.638649, 0.586422, 1)
+ambient_light_color = Color(1, 1, 1, 1)
 reflected_light_source = 2
 tonemap_mode = 3
 tonemap_white = 6.0
@@ -110,13 +112,15 @@ sdfgi_enabled = true
 [sub_resource type="CompositorEffect" id="CompositorEffect_6s10p"]
 resource_local_to_scene = false
 resource_name = ""
-enabled = false
-effect_callback_type = 4
+enabled = true
+effect_callback_type = 3
+access_resolved_color = false
+access_resolved_depth = false
 needs_motion_vectors = false
 needs_normal_roughness = false
 script = ExtResource("8_5hbym")
-regenerate = true
-camera_position = Vector3(-117.054, 50.1283, 46.7479)
+regenerate = false
+camera_position = Vector3(-22.4395, 15.6407, 81.3312)
 side_length = 400
 mesh_scale = 0.5
 wireframe = false
@@ -134,10 +138,12 @@ frequency_variance = Vector2(-0.085, 0.115)
 height_scale = 90.9
 slope_damping = 0.155
 slope_threshold = Vector2(0.84, 0.98)
-low_slope_texture_ST = Vector4(0, 0, 0, 0)
-low_slope_color = Color(0.366477, 0.373384, 0.0777902, 1)
-high_slope_texture_ST = Vector4(0, 0, 0, 0)
-high_slope_color = Color(0.1, 0.05835, 0.049, 1)
+low_slope_texture = ExtResource("8_o4ep3")
+low_slope_texture_ST = Vector4(2, 2, 1, 1)
+low_slope_color = Color(1, 1, 1, 1)
+high_slope_texture = ExtResource("8_o4ep3")
+high_slope_texture_ST = Vector4(48, 52, 1, 1)
+high_slope_color = Color(1, 0, 1, 1)
 fog_color = Color(1, 0.5, 0.9, 1)
 fog_density = 0.02
 fog_height_fade = 0.5
@@ -155,7 +161,7 @@ compositor_effects = Array[CompositorEffect]([SubResource("CompositorEffect_6s10
 [sub_resource type="QuadMesh" id="QuadMesh_yrbqa"]
 lightmap_size_hint = Vector2i(52, 52)
 material = ExtResource("12_kro42")
-size = Vector2(10, 10)
+size = Vector2(1000, 1000)
 orientation = 1
 
 [sub_resource type="BoxMesh" id="BoxMesh_kro42"]
@@ -170,26 +176,25 @@ script = ExtResource("9_sk61g")
 fog_enabled = false
 enable_editor_time = false
 enable_game_time = false
-current_time = 16.2
+current_time = 12.0
 minutes_per_day = 1.0
 metadata/_custom_type_script = "uid://deo0gxkmk2ahd"
 
 [node name="SunLight" type="DirectionalLight3D" parent="Sky3D"]
-transform = Transform3D(0, -0.524551, -0.851379, 0.749196, -0.563909, 0.347436, -0.662348, -0.63785, 0.392992, -0.851379, 0.347435, 0.392992)
-light_color = Color(0.993897, 0.854453, 0.784579, 1)
+transform = Transform3D(0, -0.999972, 0.00749758, 0.5363, 0.00632816, 0.844004, -0.844028, 0.00402095, 0.536285, 0.00749758, 0.844004, 0.536285)
 shadow_enabled = true
 
 [node name="MoonLight" type="DirectionalLight3D" parent="Sky3D"]
-transform = Transform3D(0, -0.723038, -0.690808, 0.562871, -0.570983, 0.597624, -0.826544, -0.388836, 0.406978, -0.690808, 0.597624, 0.406978)
+transform = Transform3D(0, -0.95855, 0.284925, 0.502016, 0.24642, 0.82901, -0.864858, 0.143037, 0.481208, 0.284925, 0.82901, 0.481208)
 light_color = Color(0.572549, 0.776471, 0.956863, 1)
 light_energy = 0.0
 
 [node name="Skydome" type="Node" parent="Sky3D"]
 script = ExtResource("10_p8bqm")
-sun_azimuth = -245.222
-sun_altitude = -69.6694
-moon_azimuth = -239.496
-moon_altitude = -53.3001
+sun_azimuth = -179.199
+sun_altitude = -32.4346
+moon_azimuth = -149.37
+moon_altitude = -34.0028
 fog_visible = false
 
 [node name="TimeOfDay" type="Node" parent="Sky3D"]
@@ -198,18 +203,22 @@ update_in_editor = false
 update_in_game = false
 dome_path = NodePath("../Skydome")
 total_cycle_in_minutes = 1.0
-total_hours = 16.2
+total_hours = 12.0
 day = 5
 month = 2
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="."]
-transform = Transform3D(0.999978, -0.00575738, 0.00314607, 0.00575782, 0.999983, -0.000131578, -0.00314526, 0.000149677, 0.999995, -0.0312763, -0.122346, 0.0962624)
+transform = Transform3D(0.999978, -0.00575738, 0.00314607, 0.00575782, 0.999983, -0.000131578, -0.00314526, 0.000149677, 0.999995, 0.256973, -13.5755, -0.0458298)
 gi_mode = 2
 mesh = SubResource("QuadMesh_yrbqa")
 script = ExtResource("13_1ty8j")
 sky_3d_node = NodePath("../Sky3D")
 
 [node name="MeshInstance3D2" type="MeshInstance3D" parent="."]
-transform = Transform3D(0.999978, -0.00575738, 0.00314607, 0.00575782, 0.999983, -0.000131578, -0.00314526, 0.000149677, 0.999995, 10.4658, 3.88219, 9.20296)
+transform = Transform3D(49.9989, -0.0171282, 0.101193, 0.287891, 2.97495, -0.0042318, -0.157263, 0.000445289, 32.1648, -27.9332, -15.7398, 21.9302)
+layers = 513
 mesh = SubResource("BoxMesh_kro42")
 skeleton = NodePath("../MeshInstance3D")
+
+[node name="Camera3D" type="Camera3D" parent="."]
+script = ExtResource("14_mu6w4")

--- a/Scenes/NewScene02.tscn
+++ b/Scenes/NewScene02.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=20 format=3 uid="uid://vxfj52skora1"]
+[gd_scene load_steps=22 format=3 uid="uid://vxfj52skora1"]
 
 [ext_resource type="Shader" uid="uid://cvd0x7lon1ur6" path="res://addons/sky_3d/shaders/SkyMaterial.gdshader" id="1_yrbqa"]
 [ext_resource type="Texture2D" uid="uid://c1vwcdcdvb74a" path="res://addons/sky_3d/assets/thirdparty/textures/milkyway/Milkyway.jpg" id="2_kro42"]
@@ -12,6 +12,7 @@
 [ext_resource type="Script" uid="uid://b4tkplvh7fq40" path="res://addons/sky_3d/src/Skydome.gd" id="10_p8bqm"]
 [ext_resource type="Script" uid="uid://cjmkcj8hwm7ts" path="res://addons/sky_3d/src/TimeOfDay.gd" id="11_yuxwe"]
 [ext_resource type="Material" uid="uid://bb6i0fqo0hjiv" path="res://materials/water_material.tres" id="12_kro42"]
+[ext_resource type="Script" uid="uid://c4mvk5x5up2dp" path="res://Scripts/mesh_connector.gd" id="13_1ty8j"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_bi7xu"]
 shader = ExtResource("1_yrbqa")
@@ -45,14 +46,14 @@ shader_parameter/moon_texture_flip_u = false
 shader_parameter/moon_texture_flip_v = false
 shader_parameter/moon_size = 0.07
 shader_parameter/atm_moon_mie_tint = Color(0.137255, 0.184314, 0.292196, 1)
-shader_parameter/atm_moon_mie_intensity = 0.0
+shader_parameter/atm_moon_mie_intensity = 0.607773
 shader_parameter/atm_moon_partial_mie_phase = Vector3(0.36, 1.64, 1.6)
 shader_parameter/background_texture = ExtResource("2_kro42")
 shader_parameter/background_color = Color(0.709804, 0.709804, 0.709804, 0.854902)
 shader_parameter/stars_field_color = Color(1, 1, 1, 1)
 shader_parameter/stars_field_texture = ExtResource("7_lvxco")
 shader_parameter/sky_alignment = Vector3(2.6555, -0.23935, 0.4505)
-shader_parameter/sky_rotation = -10.2028
+shader_parameter/sky_rotation = -12.3489
 shader_parameter/sky_tilt = -1.29154
 shader_parameter/stars_scintillation = 0.75
 shader_parameter/stars_scintillation_speed = 0.01
@@ -87,8 +88,8 @@ shader_parameter/cumulus_clouds_horizon_light_color = Color(0.98, 0.43, 0.15, 1)
 shader_parameter/cumulus_clouds_night_color = Color(0.090196, 0.094118, 0.129412, 1)
 shader_parameter/cumulus_clouds_partial_mie_phase = Vector3(0.957564, 1.04244, 0.412)
 shader_parameter/cumulus_clouds_mie_intensity = 1.0
-shader_parameter/moon_matrix = Basis(0, -0.890989, 0.454026, -0.637008, 0.349989, 0.686825, -0.770858, -0.289218, -0.567567)
-shader_parameter/deep_space_matrix = Basis(0.712322, 0.701853, -2.98023e-08, 0.193458, -0.196343, -0.961262, -0.674664, 0.684727, -0.275638)
+shader_parameter/moon_matrix = Basis(0, 0.485569, -0.874198, -0.979167, -0.17751, -0.098597, -0.203055, 0.855987, 0.475453)
+shader_parameter/deep_space_matrix = Basis(-0.976448, 0.215754, -7.45058e-09, 0.0594699, 0.269146, -0.961261, -0.207396, -0.938622, -0.275638)
 
 [sub_resource type="Sky" id="Sky_ew16t"]
 sky_material = SubResource("ShaderMaterial_bi7xu")
@@ -97,11 +98,12 @@ sky_material = SubResource("ShaderMaterial_bi7xu")
 background_mode = 2
 sky = SubResource("Sky_ew16t")
 ambient_light_source = 3
-ambient_light_color = Color(0.75824, 0.662375, 0.614338, 1)
-ambient_light_sky_contribution = 0.7
+ambient_light_color = Color(0.913524, 0.913524, 0.913524, 1)
 reflected_light_source = 2
 tonemap_mode = 3
 tonemap_white = 6.0
+ssr_enabled = true
+sdfgi_enabled = true
 
 [sub_resource type="CameraAttributesPractical" id="CameraAttributesPractical_ukmhn"]
 
@@ -152,7 +154,10 @@ compositor_effects = Array[CompositorEffect]([SubResource("CompositorEffect_6s10
 
 [sub_resource type="QuadMesh" id="QuadMesh_yrbqa"]
 material = ExtResource("12_kro42")
+size = Vector2(10, 10)
 orientation = 1
+
+[sub_resource type="BoxMesh" id="BoxMesh_kro42"]
 
 [node name="NewScene02" type="Node3D"]
 
@@ -161,33 +166,43 @@ environment = SubResource("Environment_quw6j")
 camera_attributes = SubResource("CameraAttributesPractical_ukmhn")
 compositor = SubResource("Compositor_pltq5")
 script = ExtResource("9_sk61g")
-enable_editor_time = false
+fog_enabled = false
+current_time = 15.1267
+minutes_per_day = 1.0
 metadata/_custom_type_script = "uid://deo0gxkmk2ahd"
 
 [node name="SunLight" type="DirectionalLight3D" parent="Sky3D"]
-transform = Transform3D(0, -0.625152, 0.780503, 0.814791, 0.4525, 0.362435, -0.579755, 0.635947, 0.509369, 0.780503, 0.362435, 0.509369)
-light_color = Color(0.994497, 0.868763, 0.805758, 1)
+transform = Transform3D(0, -0.725282, -0.688452, 0.706179, -0.487447, 0.513524, -0.708034, -0.48617, 0.512179, -0.688452, 0.513524, 0.512179)
 shadow_enabled = true
 
 [node name="MoonLight" type="DirectionalLight3D" parent="Sky3D"]
-transform = Transform3D(0, -0.637008, -0.770857, -0.890989, 0.349989, -0.289218, 0.454026, 0.686825, -0.567567, -0.770857, -0.289218, -0.567567)
+transform = Transform3D(0, -0.979167, -0.203055, 0.485569, -0.17751, 0.855986, -0.874198, -0.098597, 0.475453, -0.203055, 0.855986, 0.475453)
 light_color = Color(0.572549, 0.776471, 0.956863, 1)
 light_energy = 0.0
 
 [node name="Skydome" type="Node" parent="Sky3D"]
 script = ExtResource("10_p8bqm")
-sun_azimuth = -123.129
-sun_altitude = -68.7502
-moon_azimuth = -306.363
-moon_altitude = -106.811
+sun_azimuth = -233.352
+sun_altitude = -59.1011
+moon_azimuth = -203.126
+moon_altitude = -31.1311
+fog_visible = false
 
 [node name="TimeOfDay" type="Node" parent="Sky3D"]
 script = ExtResource("11_yuxwe")
-update_in_editor = false
 dome_path = NodePath("../Skydome")
-total_hours = 8.0
-day = 3
+total_cycle_in_minutes = 1.0
+total_hours = 15.1267
+day = 19
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="."]
-transform = Transform3D(0.999978, -0.00575738, 0.00314607, 0.00575782, 0.999983, -0.000131578, -0.00314526, 0.000149677, 0.999995, 0, 0, 0)
+transform = Transform3D(0.999978, -0.00575738, 0.00314607, 0.00575782, 0.999983, -0.000131578, -0.00314526, 0.000149677, 0.999995, -0.0312763, -0.122346, 0.0962624)
+gi_mode = 2
 mesh = SubResource("QuadMesh_yrbqa")
+script = ExtResource("13_1ty8j")
+sky_3d_node = NodePath("../Sky3D")
+
+[node name="MeshInstance3D2" type="MeshInstance3D" parent="."]
+transform = Transform3D(0.999978, -0.00575738, 0.00314607, 0.00575782, 0.999983, -0.000131578, -0.00314526, 0.000149677, 0.999995, 10.4658, 3.88219, 9.20296)
+mesh = SubResource("BoxMesh_kro42")
+skeleton = NodePath("../MeshInstance3D")

--- a/Scenes/NewScene02.tscn
+++ b/Scenes/NewScene02.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=18 format=3 uid="uid://vxfj52skora1"]
+[gd_scene load_steps=20 format=3 uid="uid://vxfj52skora1"]
 
 [ext_resource type="Shader" uid="uid://cvd0x7lon1ur6" path="res://addons/sky_3d/shaders/SkyMaterial.gdshader" id="1_yrbqa"]
 [ext_resource type="Texture2D" uid="uid://c1vwcdcdvb74a" path="res://addons/sky_3d/assets/thirdparty/textures/milkyway/Milkyway.jpg" id="2_kro42"]
@@ -11,6 +11,7 @@
 [ext_resource type="Script" uid="uid://deo0gxkmk2ahd" path="res://addons/sky_3d/src/Sky3D.gd" id="9_sk61g"]
 [ext_resource type="Script" uid="uid://b4tkplvh7fq40" path="res://addons/sky_3d/src/Skydome.gd" id="10_p8bqm"]
 [ext_resource type="Script" uid="uid://cjmkcj8hwm7ts" path="res://addons/sky_3d/src/TimeOfDay.gd" id="11_yuxwe"]
+[ext_resource type="Material" uid="uid://bb6i0fqo0hjiv" path="res://materials/water_material.tres" id="12_kro42"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_bi7xu"]
 shader = ExtResource("1_yrbqa")
@@ -44,14 +45,14 @@ shader_parameter/moon_texture_flip_u = false
 shader_parameter/moon_texture_flip_v = false
 shader_parameter/moon_size = 0.07
 shader_parameter/atm_moon_mie_tint = Color(0.137255, 0.184314, 0.292196, 1)
-shader_parameter/atm_moon_mie_intensity = 0.101665
+shader_parameter/atm_moon_mie_intensity = 0.0
 shader_parameter/atm_moon_partial_mie_phase = Vector3(0.36, 1.64, 1.6)
 shader_parameter/background_texture = ExtResource("2_kro42")
 shader_parameter/background_color = Color(0.709804, 0.709804, 0.709804, 0.854902)
 shader_parameter/stars_field_color = Color(1, 1, 1, 1)
 shader_parameter/stars_field_texture = ExtResource("7_lvxco")
 shader_parameter/sky_alignment = Vector3(2.6555, -0.23935, 0.4505)
-shader_parameter/sky_rotation = -11.3338
+shader_parameter/sky_rotation = -10.2028
 shader_parameter/sky_tilt = -1.29154
 shader_parameter/stars_scintillation = 0.75
 shader_parameter/stars_scintillation_speed = 0.01
@@ -86,8 +87,8 @@ shader_parameter/cumulus_clouds_horizon_light_color = Color(0.98, 0.43, 0.15, 1)
 shader_parameter/cumulus_clouds_night_color = Color(0.090196, 0.094118, 0.129412, 1)
 shader_parameter/cumulus_clouds_partial_mie_phase = Vector3(0.957564, 1.04244, 0.412)
 shader_parameter/cumulus_clouds_mie_intensity = 1.0
-shader_parameter/moon_matrix = Basis(0, -0.685553, 0.728023, -0.999991, -0.00316192, -0.00297747, 0.00434316, -0.728016, -0.685546)
-shader_parameter/deep_space_matrix = Basis(-0.331804, 0.943348, 0, 0.260023, 0.0914578, -0.961262, -0.906804, -0.31895, -0.275638)
+shader_parameter/moon_matrix = Basis(0, -0.890989, 0.454026, -0.637008, 0.349989, 0.686825, -0.770858, -0.289218, -0.567567)
+shader_parameter/deep_space_matrix = Basis(0.712322, 0.701853, -2.98023e-08, 0.193458, -0.196343, -0.961262, -0.674664, 0.684727, -0.275638)
 
 [sub_resource type="Sky" id="Sky_ew16t"]
 sky_material = SubResource("ShaderMaterial_bi7xu")
@@ -96,7 +97,8 @@ sky_material = SubResource("ShaderMaterial_bi7xu")
 background_mode = 2
 sky = SubResource("Sky_ew16t")
 ambient_light_source = 3
-ambient_light_color = Color(1, 1, 1, 1)
+ambient_light_color = Color(0.75824, 0.662375, 0.614338, 1)
+ambient_light_sky_contribution = 0.7
 reflected_light_source = 2
 tonemap_mode = 3
 tonemap_white = 6.0
@@ -106,13 +108,13 @@ tonemap_white = 6.0
 [sub_resource type="CompositorEffect" id="CompositorEffect_6s10p"]
 resource_local_to_scene = false
 resource_name = ""
-enabled = true
+enabled = false
 effect_callback_type = 4
 needs_motion_vectors = false
 needs_normal_roughness = false
 script = ExtResource("8_5hbym")
-regenerate = false
-camera_position = Vector3(112.607, 15.8286, 74.9659)
+regenerate = true
+camera_position = Vector3(-117.054, 50.1283, 46.7479)
 side_length = 400
 mesh_scale = 0.5
 wireframe = false
@@ -130,17 +132,27 @@ frequency_variance = Vector2(-0.085, 0.115)
 height_scale = 90.9
 slope_damping = 0.155
 slope_threshold = Vector2(0.84, 0.98)
+low_slope_texture_ST = Vector4(0, 0, 0, 0)
 low_slope_color = Color(0.366477, 0.373384, 0.0777902, 1)
+high_slope_texture_ST = Vector4(0, 0, 0, 0)
 high_slope_color = Color(0.1, 0.05835, 0.049, 1)
 fog_color = Color(1, 0.5, 0.9, 1)
 fog_density = 0.02
 fog_height_fade = 0.5
 fog_start = 100.0
 ambient_light = Color(0.192, 0.2712, 0.3, 1)
+light_color = Color(1, 1, 1, 1)
+light_intensity = 1.0
+specular_strength = 0.5
+shininess = 32.0
 metadata/_custom_type_script = "uid://7n58awc2ols0"
 
 [sub_resource type="Compositor" id="Compositor_pltq5"]
 compositor_effects = Array[CompositorEffect]([SubResource("CompositorEffect_6s10p")])
+
+[sub_resource type="QuadMesh" id="QuadMesh_yrbqa"]
+material = ExtResource("12_kro42")
+orientation = 1
 
 [node name="NewScene02" type="Node3D"]
 
@@ -149,27 +161,33 @@ environment = SubResource("Environment_quw6j")
 camera_attributes = SubResource("CameraAttributesPractical_ukmhn")
 compositor = SubResource("Compositor_pltq5")
 script = ExtResource("9_sk61g")
-current_time = 12.3739
+enable_editor_time = false
 metadata/_custom_type_script = "uid://deo0gxkmk2ahd"
 
 [node name="SunLight" type="DirectionalLight3D" parent="Sky3D"]
-transform = Transform3D(0, -0.992243, -0.124312, 0.631998, -0.0963381, 0.768959, -0.77497, -0.0785649, 0.627095, -0.124312, 0.768959, 0.627095)
+transform = Transform3D(0, -0.625152, 0.780503, 0.814791, 0.4525, 0.362435, -0.579755, 0.635947, 0.509369, 0.780503, 0.362435, 0.509369)
+light_color = Color(0.994497, 0.868763, 0.805758, 1)
 shadow_enabled = true
 
 [node name="MoonLight" type="DirectionalLight3D" parent="Sky3D"]
-transform = Transform3D(0, -0.999991, 0.00434316, -0.685553, -0.00316192, -0.728016, 0.728023, -0.00297747, -0.685546, 0.00434316, -0.728016, -0.685546)
+transform = Transform3D(0, -0.637008, -0.770857, -0.890989, 0.349989, -0.289218, 0.454026, 0.686825, -0.567567, -0.770857, -0.289218, -0.567567)
 light_color = Color(0.572549, 0.776471, 0.956863, 1)
 light_energy = 0.0
 
 [node name="Skydome" type="Node" parent="Sky3D"]
 script = ExtResource("10_p8bqm")
-sun_azimuth = -191.213
-sun_altitude = -39.7395
-moon_azimuth = -0.362983
-moon_altitude = -136.72
+sun_azimuth = -123.129
+sun_altitude = -68.7502
+moon_azimuth = -306.363
+moon_altitude = -106.811
 
 [node name="TimeOfDay" type="Node" parent="Sky3D"]
 script = ExtResource("11_yuxwe")
+update_in_editor = false
 dome_path = NodePath("../Skydome")
-total_hours = 12.3739
-day = 2
+total_hours = 8.0
+day = 3
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+transform = Transform3D(0.999978, -0.00575738, 0.00314607, 0.00575782, 0.999983, -0.000131578, -0.00314526, 0.000149677, 0.999995, 0, 0, 0)
+mesh = SubResource("QuadMesh_yrbqa")

--- a/Scenes/NewScene02.tscn
+++ b/Scenes/NewScene02.tscn
@@ -53,7 +53,7 @@ shader_parameter/background_color = Color(0.709804, 0.709804, 0.709804, 0.854902
 shader_parameter/stars_field_color = Color(1, 1, 1, 1)
 shader_parameter/stars_field_texture = ExtResource("7_lvxco")
 shader_parameter/sky_alignment = Vector3(2.6555, -0.23935, 0.4505)
-shader_parameter/sky_rotation = -12.3489
+shader_parameter/sky_rotation = -12.9129
 shader_parameter/sky_tilt = -1.29154
 shader_parameter/stars_scintillation = 0.75
 shader_parameter/stars_scintillation_speed = 0.01
@@ -88,8 +88,8 @@ shader_parameter/cumulus_clouds_horizon_light_color = Color(0.98, 0.43, 0.15, 1)
 shader_parameter/cumulus_clouds_night_color = Color(0.090196, 0.094118, 0.129412, 1)
 shader_parameter/cumulus_clouds_partial_mie_phase = Vector3(0.957564, 1.04244, 0.412)
 shader_parameter/cumulus_clouds_mie_intensity = 1.0
-shader_parameter/moon_matrix = Basis(0, 0.485569, -0.874198, -0.979167, -0.17751, -0.098597, -0.203055, 0.855987, 0.475453)
-shader_parameter/deep_space_matrix = Basis(-0.976448, 0.215754, -7.45058e-09, 0.0594699, 0.269146, -0.961261, -0.207396, -0.938622, -0.275638)
+shader_parameter/moon_matrix = Basis(0, 0.562871, -0.826544, -0.723038, -0.570983, -0.388836, -0.690808, 0.597623, 0.406978)
+shader_parameter/deep_space_matrix = Basis(-0.940541, -0.339679, 1.49012e-08, -0.0936285, 0.259249, -0.961261, 0.326521, -0.904106, -0.275638)
 
 [sub_resource type="Sky" id="Sky_ew16t"]
 sky_material = SubResource("ShaderMaterial_bi7xu")
@@ -98,7 +98,7 @@ sky_material = SubResource("ShaderMaterial_bi7xu")
 background_mode = 2
 sky = SubResource("Sky_ew16t")
 ambient_light_source = 3
-ambient_light_color = Color(0.913524, 0.913524, 0.913524, 1)
+ambient_light_color = Color(0.742874, 0.638649, 0.586422, 1)
 reflected_light_source = 2
 tonemap_mode = 3
 tonemap_white = 6.0
@@ -153,6 +153,7 @@ metadata/_custom_type_script = "uid://7n58awc2ols0"
 compositor_effects = Array[CompositorEffect]([SubResource("CompositorEffect_6s10p")])
 
 [sub_resource type="QuadMesh" id="QuadMesh_yrbqa"]
+lightmap_size_hint = Vector2i(52, 52)
 material = ExtResource("12_kro42")
 size = Vector2(10, 10)
 orientation = 1
@@ -167,33 +168,39 @@ camera_attributes = SubResource("CameraAttributesPractical_ukmhn")
 compositor = SubResource("Compositor_pltq5")
 script = ExtResource("9_sk61g")
 fog_enabled = false
-current_time = 15.1267
+enable_editor_time = false
+enable_game_time = false
+current_time = 16.2
 minutes_per_day = 1.0
 metadata/_custom_type_script = "uid://deo0gxkmk2ahd"
 
 [node name="SunLight" type="DirectionalLight3D" parent="Sky3D"]
-transform = Transform3D(0, -0.725282, -0.688452, 0.706179, -0.487447, 0.513524, -0.708034, -0.48617, 0.512179, -0.688452, 0.513524, 0.512179)
+transform = Transform3D(0, -0.524551, -0.851379, 0.749196, -0.563909, 0.347436, -0.662348, -0.63785, 0.392992, -0.851379, 0.347435, 0.392992)
+light_color = Color(0.993897, 0.854453, 0.784579, 1)
 shadow_enabled = true
 
 [node name="MoonLight" type="DirectionalLight3D" parent="Sky3D"]
-transform = Transform3D(0, -0.979167, -0.203055, 0.485569, -0.17751, 0.855986, -0.874198, -0.098597, 0.475453, -0.203055, 0.855986, 0.475453)
+transform = Transform3D(0, -0.723038, -0.690808, 0.562871, -0.570983, 0.597624, -0.826544, -0.388836, 0.406978, -0.690808, 0.597624, 0.406978)
 light_color = Color(0.572549, 0.776471, 0.956863, 1)
 light_energy = 0.0
 
 [node name="Skydome" type="Node" parent="Sky3D"]
 script = ExtResource("10_p8bqm")
-sun_azimuth = -233.352
-sun_altitude = -59.1011
-moon_azimuth = -203.126
-moon_altitude = -31.1311
+sun_azimuth = -245.222
+sun_altitude = -69.6694
+moon_azimuth = -239.496
+moon_altitude = -53.3001
 fog_visible = false
 
 [node name="TimeOfDay" type="Node" parent="Sky3D"]
 script = ExtResource("11_yuxwe")
+update_in_editor = false
+update_in_game = false
 dome_path = NodePath("../Skydome")
 total_cycle_in_minutes = 1.0
-total_hours = 15.1267
-day = 19
+total_hours = 16.2
+day = 5
+month = 2
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="."]
 transform = Transform3D(0.999978, -0.00575738, 0.00314607, 0.00575782, 0.999983, -0.000131578, -0.00314526, 0.000149677, 0.999995, -0.0312763, -0.122346, 0.0962624)

--- a/Scripts/mesh_connector.gd
+++ b/Scripts/mesh_connector.gd
@@ -1,0 +1,28 @@
+@tool
+extends MeshInstance3D
+
+@export var sky_3d_node: NodePath
+@onready var sky_3d: Sky3D = get_node(sky_3d_node)
+
+func _process(delta):
+	if !sky_3d or !sky_3d.tod:
+		return
+		
+	var material = get_active_material(0)
+	if material is ShaderMaterial:
+		# Get normalized time (0-1 range for full day cycle)
+		var tod = sky_3d.tod
+		var time_normalized = tod.total_hours / 24.0
+		
+		# Sync all properties
+		material.set_shader_parameter("sun_direction", -sky_3d.sun.global_transform.basis.z)
+		material.set_shader_parameter("sun_color", sky_3d.sun.light_color)
+		material.set_shader_parameter("sun_energy", sky_3d.sun.light_energy)
+		material.set_shader_parameter("time_of_day", time_normalized)
+		material.set_shader_parameter("ambient_light", 
+			sky_3d.environment.ambient_light_color * sky_3d.environment.ambient_light_energy)
+		
+		# Optional: Sync moon properties if needed
+		if sky_3d.moon:
+			material.set_shader_parameter("moon_direction", -sky_3d.moon.global_transform.basis.z)
+			material.set_shader_parameter("moon_color", sky_3d.moon.light_color)

--- a/Scripts/mesh_connector.gd.uid
+++ b/Scripts/mesh_connector.gd.uid
@@ -1,0 +1,1 @@
+uid://c4mvk5x5up2dp

--- a/materials/water_material.tres
+++ b/materials/water_material.tres
@@ -1,3 +1,12 @@
-[gd_resource type="ShaderMaterial" format=3 uid="uid://bb6i0fqo0hjiv"]
+[gd_resource type="ShaderMaterial" load_steps=2 format=3 uid="uid://bb6i0fqo0hjiv"]
+
+[ext_resource type="Shader" uid="uid://dt3ad5f788os0" path="res://shaders/water.gdshader" id="1_eplgm"]
 
 [resource]
+render_priority = 0
+shader = ExtResource("1_eplgm")
+shader_parameter/water_color = Color(0, 0.2, 0.5, 1)
+shader_parameter/wave_speed = 0.5
+shader_parameter/wave_height = 0.1
+shader_parameter/edge_softness = 0.5
+shader_parameter/transparency = 2.41

--- a/materials/water_material.tres
+++ b/materials/water_material.tres
@@ -1,0 +1,3 @@
+[gd_resource type="ShaderMaterial" format=3 uid="uid://bb6i0fqo0hjiv"]
+
+[resource]

--- a/materials/water_material.tres
+++ b/materials/water_material.tres
@@ -5,11 +5,3 @@
 [resource]
 render_priority = 0
 shader = ExtResource("1_eplgm")
-shader_parameter/water_color = Color(0, 0.2, 1, 1)
-shader_parameter/wave_speed = 0.7
-shader_parameter/wave_height = 0.1
-shader_parameter/sun_direction = Vector3(-0.912703, -0.0900668, -0.398575)
-shader_parameter/sun_color = Vector3(1, 1, 1)
-shader_parameter/sun_energy = 1.0
-shader_parameter/ambient_light = Vector3(0.2, 0.2, 0.2)
-shader_parameter/time_of_day = 0.282031

--- a/materials/water_material.tres
+++ b/materials/water_material.tres
@@ -5,3 +5,13 @@
 [resource]
 render_priority = 0
 shader = ExtResource("1_eplgm")
+shader_parameter/water_color = Color(0, 0.2, 0.5, 1)
+shader_parameter/wave_speed = 2.5
+shader_parameter/wave_height = 0.515
+shader_parameter/sun_direction = Vector3(-0.00749758, -0.844004, -0.536285)
+shader_parameter/sun_color = Vector3(1, 1, 1)
+shader_parameter/sun_energy = 1.0
+shader_parameter/ambient_light = Vector3(0.2, 0.2, 0.2)
+shader_parameter/time_of_day = 0.5
+shader_parameter/moon_direction = Vector3(-0.284925, -0.82901, -0.481208)
+shader_parameter/moon_color = Vector3(0.8, 0.85, 1)

--- a/materials/water_material.tres
+++ b/materials/water_material.tres
@@ -9,4 +9,5 @@ shader_parameter/water_color = Color(0, 0.2, 0.5, 1)
 shader_parameter/wave_speed = 0.5
 shader_parameter/wave_height = 0.1
 shader_parameter/edge_softness = 0.5
-shader_parameter/transparency = 2.41
+shader_parameter/transparency = 0.8
+shader_parameter/reflection_intensity = 0.5

--- a/materials/water_material.tres
+++ b/materials/water_material.tres
@@ -5,9 +5,11 @@
 [resource]
 render_priority = 0
 shader = ExtResource("1_eplgm")
-shader_parameter/water_color = Color(0, 0.2, 0.5, 1)
-shader_parameter/wave_speed = 0.5
+shader_parameter/water_color = Color(0, 0.2, 1, 1)
+shader_parameter/wave_speed = 0.7
 shader_parameter/wave_height = 0.1
-shader_parameter/edge_softness = 0.5
-shader_parameter/transparency = 0.8
-shader_parameter/reflection_intensity = 0.5
+shader_parameter/sun_direction = Vector3(-0.912703, -0.0900668, -0.398575)
+shader_parameter/sun_color = Vector3(1, 1, 1)
+shader_parameter/sun_energy = 1.0
+shader_parameter/ambient_light = Vector3(0.2, 0.2, 0.2)
+shader_parameter/time_of_day = 0.282031

--- a/shaders/water.gdshader
+++ b/shaders/water.gdshader
@@ -1,0 +1,14 @@
+shader_type spatial;
+
+void vertex() {
+	// Called for every vertex the material is visible on.
+}
+
+void fragment() {
+	// Called for every pixel the material is visible on.
+}
+
+//void light() {
+//	// Called for every pixel for every light affecting the material.
+//	// Uncomment to replace the default light processing function with this one.
+//}

--- a/shaders/water.gdshader
+++ b/shaders/water.gdshader
@@ -1,11 +1,12 @@
 shader_type spatial;
+render_mode depth_draw_always;
 
 uniform sampler2D SCREEN_TEXTURE : hint_screen_texture, filter_linear_mipmap;
 uniform vec3 water_color : source_color = vec3(0.0, 0.2, 0.5);
 uniform float wave_speed = 0.5;
 uniform float wave_height = 0.1;
 
-// Sky3D connection with proper time handling
+// Sky3D sync
 uniform vec3 sun_direction = vec3(0.0, 1.0, 0.0);
 uniform vec3 sun_color = vec3(1.0);
 uniform float sun_energy = 1.0;
@@ -52,6 +53,9 @@ void fragment() {
     
     // Material properties
     METALLIC = mix(0.1, 0.3, day_intensity);
+	//METALLIC = 0.3;
     ROUGHNESS = mix(0.15, 0.1, day_intensity); // Smoother during day
+	//ROUGHNESS = 0.1;
     SPECULAR = mix(0.3, 0.5, day_intensity);
+	//SPECULAR = 0.5;
 }

--- a/shaders/water.gdshader
+++ b/shaders/water.gdshader
@@ -1,11 +1,32 @@
 shader_type spatial;
 
+uniform vec3 water_color : source_color = vec3(0.0, 0.2, 0.5);
+uniform float wave_speed = 0.5;
+uniform float wave_height = 0.1;
+uniform float edge_softness = 0.5;
+uniform float transparency = 0.8;
+uniform sampler2D SCREEN_TEXTURE : hint_screen_texture, filter_linear_mipmap;
+
 void vertex() {
 	// Called for every vertex the material is visible on.
+	VERTEX.y += sin(TIME * wave_speed + VERTEX.x * 10.0) * wave_height;
+	VERTEX.y += cos(TIME * wave_speed * 0.7 + VERTEX.z * 8.0) * wave_height * 0.7;
 }
+
 
 void fragment() {
 	// Called for every pixel the material is visible on.
+	float edge_factor = smoothstep(0.0, edge_softness, 1.0 - abs(dot(NORMAL, VIEW)));
+	float fresnel = pow(1.0 - max(0.0, dot(NORMAL, VIEW)), 2.0);
+	//vec3 reflection = textureLod(SCREEN_TEXTURE, SCREEN_UV - NORMAL.xz * 0.1, 0.0),.rgb;
+	//vec2 padding = vec2(0.0, 0.0)
+	
+	//ALBEDO = mix(water_color, vec2(padding), fresnel);
+	ALBEDO = water_color;
+	ALPHA = transparency * edge_factor;
+	METALLIC = 0.2;
+	ROUGHNESS = 0.1;
+	SPECULAR = 0.5;
 }
 
 //void light() {

--- a/shaders/water.gdshader
+++ b/shaders/water.gdshader
@@ -24,9 +24,8 @@ void vertex() {
 }
 
 void fragment() {
-    // Calculate day/night intensity (accounts for dawn/dusk transitions)
-    float day_intensity = smoothstep(0.35, 0.5, time_of_day) - smoothstep(0.5, 0.65, time_of_day);
-    float night_intensity = 1.0 - smoothstep(0.2, 0.3, time_of_day) + smoothstep(0.7, 0.8, time_of_day);
+	float day_intensity = smoothstep(0.4, 0.6, time_of_day); // Smoother day/night transition
+	float night_visibility = 0.3; // Minimum visibility at night (30% of base color)
     
     // Sample reflection
     vec2 ref_uv = SCREEN_UV - NORMAL.xz * mix(0.05, 0.15, day_intensity);
@@ -34,8 +33,8 @@ void fragment() {
     vec3 reflection = textureLod(SCREEN_TEXTURE, ref_uv, 0.0).rgb;
     
     // Calculate lighting contributions
-    vec3 sun_light = sun_color * sun_energy * day_intensity * max(0.0, dot(NORMAL, sun_direction));
-    vec3 moon_light = moon_color * night_intensity * 0.3 * max(0.0, dot(NORMAL, moon_direction));
+    vec3 night_color = water_color * vec3(0.5, 0.6, 0.8); // Blue-ish tint at night
+	vec3 base_color = mix(night_color, water_color, day_intensity);
     vec3 ambient = ambient_light * mix(0.8, 0.3, day_intensity);
     
     // Fresnel effect
@@ -44,7 +43,7 @@ void fragment() {
     // Final color composition
     ALBEDO = mix(
         water_color * ambient,
-        reflection * (sun_light + moon_light + ambient),
+        reflection * (base_color + ambient),
         fresnel
     );
     

--- a/shaders/water.gdshader
+++ b/shaders/water.gdshader
@@ -1,11 +1,13 @@
 shader_type spatial;
 
+uniform sampler2D SCREEN_TEXTURE : hint_screen_texture, filter_linear_mipmap;
+
 uniform vec3 water_color : source_color = vec3(0.0, 0.2, 0.5);
 uniform float wave_speed = 0.5;
 uniform float wave_height = 0.1;
 uniform float edge_softness = 0.5;
 uniform float transparency = 0.8;
-uniform sampler2D SCREEN_TEXTURE : hint_screen_texture, filter_linear_mipmap;
+uniform float reflection_intensity = 0.5;
 
 void vertex() {
 	// Called for every vertex the material is visible on.
@@ -18,11 +20,14 @@ void fragment() {
 	// Called for every pixel the material is visible on.
 	float edge_factor = smoothstep(0.0, edge_softness, 1.0 - abs(dot(NORMAL, VIEW)));
 	float fresnel = pow(1.0 - max(0.0, dot(NORMAL, VIEW)), 2.0);
-	//vec3 reflection = textureLod(SCREEN_TEXTURE, SCREEN_UV - NORMAL.xz * 0.1, 0.0),.rgb;
-	//vec2 padding = vec2(0.0, 0.0)
 	
-	//ALBEDO = mix(water_color, vec2(padding), fresnel);
-	ALBEDO = water_color;
+	vec2 ref_uv = SCREEN_UV - NORMAL.xz * 0.1;
+	ref_uv = clamp(ref_uv, vec2(0.001), vec2(0.999));
+	
+	vec4 screen_color = textureLod(SCREEN_TEXTURE, ref_uv, 0.0);
+    vec3 reflection = screen_color.rgb;
+	
+	ALBEDO = mix(water_color, reflection, fresnel * reflection_intensity);
 	ALPHA = transparency * edge_factor;
 	METALLIC = 0.2;
 	ROUGHNESS = 0.1;

--- a/shaders/water.gdshader
+++ b/shaders/water.gdshader
@@ -11,9 +11,8 @@ uniform vec3 sun_direction = vec3(0.0, 1.0, 0.0);
 uniform vec3 sun_color = vec3(1.0);
 uniform float sun_energy = 1.0;
 uniform vec3 ambient_light = vec3(0.2);
-uniform float time_of_day = 0.5; // 0-1 range (0=midnight, 0.5=noon)
+uniform float time_of_day = 0.5;
 
-// Moon lighting (optional)
 uniform vec3 moon_direction = vec3(0.0, -1.0, 0.0);
 uniform vec3 moon_color = vec3(0.8, 0.85, 1.0);
 
@@ -25,8 +24,7 @@ void vertex() {
 }
 
 void fragment() {
-	float day_intensity = smoothstep(0.4, 0.6, time_of_day); // Smoother day/night transition
-	float night_visibility = 0.3; // Minimum visibility at night (30% of base color)
+    float day_intensity = smoothstep(0.4, 0.6, time_of_day);
     
     // Sample reflection
     vec2 ref_uv = SCREEN_UV - NORMAL.xz * mix(0.05, 0.15, day_intensity);
@@ -34,28 +32,17 @@ void fragment() {
     vec3 reflection = textureLod(SCREEN_TEXTURE, ref_uv, 0.0).rgb;
     
     // Calculate lighting contributions
-    vec3 night_color = water_color * vec3(0.5, 0.6, 0.8); // Blue-ish tint at night
-	vec3 base_color = mix(night_color, water_color, day_intensity);
+    vec3 night_color = water_color * vec3(0.5, 0.6, 0.8);
+    vec3 base_color = mix(night_color, water_color, day_intensity);
     vec3 ambient = ambient_light * mix(0.8, 0.3, day_intensity);
     
-    // Fresnel effect
     float fresnel = pow(1.0 - max(0.0, dot(NORMAL, VIEW)), 2.0);
     
-    // Final color composition
-    ALBEDO = mix(
-        water_color * ambient,
-        reflection * (base_color + ambient),
-        fresnel
-    );
-    
-    // Dynamic transparency
+    ALBEDO = mix(water_color * ambient, reflection * (base_color + ambient), fresnel);
     ALPHA = mix(0.7, 0.85, day_intensity);
     
     // Material properties
     METALLIC = mix(0.1, 0.3, day_intensity);
-	//METALLIC = 0.3;
-    ROUGHNESS = mix(0.15, 0.1, day_intensity); // Smoother during day
-	//ROUGHNESS = 0.1;
+    ROUGHNESS = mix(0.15, 0.1, day_intensity);
     SPECULAR = mix(0.3, 0.5, day_intensity);
-	//SPECULAR = 0.5;
 }

--- a/shaders/water.gdshader
+++ b/shaders/water.gdshader
@@ -1,40 +1,58 @@
 shader_type spatial;
 
 uniform sampler2D SCREEN_TEXTURE : hint_screen_texture, filter_linear_mipmap;
-
 uniform vec3 water_color : source_color = vec3(0.0, 0.2, 0.5);
 uniform float wave_speed = 0.5;
 uniform float wave_height = 0.1;
-uniform float edge_softness = 0.5;
-uniform float transparency = 0.8;
-uniform float reflection_intensity = 0.5;
+
+// Sky3D connection with proper time handling
+uniform vec3 sun_direction = vec3(0.0, 1.0, 0.0);
+uniform vec3 sun_color = vec3(1.0);
+uniform float sun_energy = 1.0;
+uniform vec3 ambient_light = vec3(0.2);
+uniform float time_of_day = 0.5; // 0-1 range (0=midnight, 0.5=noon)
+
+// Moon lighting (optional)
+uniform vec3 moon_direction = vec3(0.0, -1.0, 0.0);
+uniform vec3 moon_color = vec3(0.8, 0.85, 1.0);
 
 void vertex() {
-	// Called for every vertex the material is visible on.
-	VERTEX.y += sin(TIME * wave_speed + VERTEX.x * 10.0) * wave_height;
-	VERTEX.y += cos(TIME * wave_speed * 0.7 + VERTEX.z * 8.0) * wave_height * 0.7;
+    // Wave animation with time-of-day influence
+    float wave_strength = mix(0.7, 1.2, smoothstep(0.4, 0.6, time_of_day));
+    VERTEX.y += sin(TIME * wave_speed + VERTEX.x * 10.0) * wave_height * wave_strength;
+    VERTEX.y += cos(TIME * wave_speed * 0.7 + VERTEX.z * 8.0) * wave_height * 0.7 * wave_strength;
 }
-
 
 void fragment() {
-	// Called for every pixel the material is visible on.
-	float edge_factor = smoothstep(0.0, edge_softness, 1.0 - abs(dot(NORMAL, VIEW)));
-	float fresnel = pow(1.0 - max(0.0, dot(NORMAL, VIEW)), 2.0);
-	
-	vec2 ref_uv = SCREEN_UV - NORMAL.xz * 0.1;
-	ref_uv = clamp(ref_uv, vec2(0.001), vec2(0.999));
-	
-	vec4 screen_color = textureLod(SCREEN_TEXTURE, ref_uv, 0.0);
-    vec3 reflection = screen_color.rgb;
-	
-	ALBEDO = mix(water_color, reflection, fresnel * reflection_intensity);
-	ALPHA = transparency * edge_factor;
-	METALLIC = 0.2;
-	ROUGHNESS = 0.1;
-	SPECULAR = 0.5;
+    // Calculate day/night intensity (accounts for dawn/dusk transitions)
+    float day_intensity = smoothstep(0.35, 0.5, time_of_day) - smoothstep(0.5, 0.65, time_of_day);
+    float night_intensity = 1.0 - smoothstep(0.2, 0.3, time_of_day) + smoothstep(0.7, 0.8, time_of_day);
+    
+    // Sample reflection
+    vec2 ref_uv = SCREEN_UV - NORMAL.xz * mix(0.05, 0.15, day_intensity);
+    ref_uv = clamp(ref_uv, vec2(0.001), vec2(0.999));
+    vec3 reflection = textureLod(SCREEN_TEXTURE, ref_uv, 0.0).rgb;
+    
+    // Calculate lighting contributions
+    vec3 sun_light = sun_color * sun_energy * day_intensity * max(0.0, dot(NORMAL, sun_direction));
+    vec3 moon_light = moon_color * night_intensity * 0.3 * max(0.0, dot(NORMAL, moon_direction));
+    vec3 ambient = ambient_light * mix(0.8, 0.3, day_intensity);
+    
+    // Fresnel effect
+    float fresnel = pow(1.0 - max(0.0, dot(NORMAL, VIEW)), 2.0);
+    
+    // Final color composition
+    ALBEDO = mix(
+        water_color * ambient,
+        reflection * (sun_light + moon_light + ambient),
+        fresnel
+    );
+    
+    // Dynamic transparency
+    ALPHA = mix(0.7, 0.85, day_intensity);
+    
+    // Material properties
+    METALLIC = mix(0.1, 0.3, day_intensity);
+    ROUGHNESS = mix(0.15, 0.1, day_intensity); // Smoother during day
+    SPECULAR = mix(0.3, 0.5, day_intensity);
 }
-
-//void light() {
-//	// Called for every pixel for every light affecting the material.
-//	// Uncomment to replace the default light processing function with this one.
-//}

--- a/shaders/water.gdshader.uid
+++ b/shaders/water.gdshader.uid
@@ -1,0 +1,1 @@
+uid://dt3ad5f788os0


### PR DESCRIPTION
Added of simple water shader in GDshader language.
Changed render queue of terrain to pre-transparent so you can see the water intersect(?) with it.

Features: Vertex displacement. Fresnel reflection
And intergrated it to work with the Sky3D plugin: https://github.com/TokisanGames/Sky3D

It just uses a mesh_connector script to trace the real-time values of the Sky system and adjusts the water, reflections etc accordingly.

<img width="1894" height="832" alt="image" src="https://github.com/user-attachments/assets/1a7c7449-404a-49fd-916f-fec967445ba6" />